### PR TITLE
Bump dependency version in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Kwik is available in the Maven Central Repository. To use it in your project, ad
     <dependency>
         <groupId>tech.kwik</groupId>
         <artifactId>kwik</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.13</version>
     </dependency>
 
 ### Java Module System


### PR DESCRIPTION
The successive lines mention JPMS / Java Module support, but it seems like the version `0.8.12` that was stated does not support JPMS, it was added in `0.8.13`.

Bumping version in README maintains correctness 