### PR TITLE
Fix #70

### DIFF
--- a/core/src/main/java/tech/kwik/core/server/impl/ServerConnectorImpl.java
+++ b/core/src/main/java/tech/kwik/core/server/impl/ServerConnectorImpl.java
@@ -582,14 +582,14 @@ public class ServerConnectorImpl implements ServerConnector {
 
         @Override
         public ServerConnector build() throws SocketException, CertificateException {
-            if (port == 0) {
-                throw new IllegalStateException("port number not set");
-            }
             if (certificateFile == null && keyStore == null) {
                 throw new IllegalStateException("server certificate not set");
             }
 
-            if (socket == null) {
+            if (socket == null || socket.getLocalPort() == 0) {
+                if (port == 0) {
+                    throw new IllegalStateException("port number not set");
+                }
                 socket = new DatagramSocket(port);
             }
 


### PR DESCRIPTION
Fixes ServerConnector builder requiring port when a DatagramSocket with a port is already supplied.