### PR TITLE
add tls-exporter api as par RFC 8446, Section 7.5

### DIFF
--- a/core/src/main/java/tech/kwik/core/QuicConnection.java
+++ b/core/src/main/java/tech/kwik/core/QuicConnection.java
@@ -130,4 +130,15 @@ public interface QuicConnection extends DatagramExtension {
     void close(long applicationErrorCode, String errorReason);
 
     Statistics getStats();
+
+    /**
+     * Derives keying material from the TLS 1.3 session using the exporter API (RFC 8446, Section 7.5).
+     *
+     * @param label       the exporter label (e.g. "EXPORTER-my-protocol")
+     * @param context     the context value (may be empty)
+     * @param length      desired output length in bytes
+     * @return the derived keying material
+     * @throws IllegalStateException if the handshake is not complete
+     */
+    byte[] exportKeyingMaterial(String label, byte[] context, int length);
 }

--- a/core/src/main/java/tech/kwik/core/crypto/CryptoStream.java
+++ b/core/src/main/java/tech/kwik/core/crypto/CryptoStream.java
@@ -406,6 +406,11 @@ public class CryptoStream {
             @Override
             public void received(CertificateRequestMessage certificateRequestMessage, ProtectionKeysType protectionKeysType) throws TlsProtocolException, IOException {
             }
+
+            @Override
+            public byte[] exportKeyingMaterial(String label, byte[] context, int length) {
+                throw new IllegalStateException("TLS handshake not complete");
+            }
         };
     }
 

--- a/core/src/main/java/tech/kwik/core/impl/QuicConnectionImpl.java
+++ b/core/src/main/java/tech/kwik/core/impl/QuicConnectionImpl.java
@@ -966,6 +966,11 @@ public abstract class QuicConnectionImpl implements QuicConnection, PacketProces
     }
 
     @Override
+    public byte[] exportKeyingMaterial(String label, byte[] context, int length) {
+        return getTlsEngine().exportKeyingMaterial(label, context, length);
+    }
+
+    @Override
     public QuicVersion getQuicVersion() {
         return quicVersion.getVersion().toQuicVersion();
     }


### PR DESCRIPTION
This commit introduces tls-exporter api, which is cruial for avoding MITM attack, via channel binding. Provided by agent15 commit dced25ba31e794a9c1e8aa90c9b5c359900cff18 (https://github.com/ptrd/agent15/pull/8).