### PR TITLE
fix loss detection on fast machines

### DIFF
--- a/core/src/main/java/tech/kwik/core/recovery/LossDetector.java
+++ b/core/src/main/java/tech/kwik/core/recovery/LossDetector.java
@@ -46,6 +46,9 @@ public class LossDetector {
     private final QLog qLog;
     private final float kTimeThreshold = 9f/8f;
     private final int kPacketThreshold = 3;
+    // https://www.rfc-editor.org/rfc/rfc9002.html#appendix-A.1
+    // "kGranularity: The RECOMMENDED value is 1ms."
+    private final int kGranularity = 1;
     private final SortedMap<Long, PacketStatus> packetSentLog;
     private final AtomicInteger ackElicitingInFlight;
     private volatile long largestAcked = -1;
@@ -174,7 +177,9 @@ public class LossDetector {
         }
 
         int lossDelay = (int) (kTimeThreshold * Integer.max(rttEstimater.getSmoothedRtt(), rttEstimater.getLatestRtt()));
-        assert(lossDelay > 0);  // Minimum time of kGranularity before packets are deemed lost
+        // https://www.rfc-editor.org/rfc/rfc9002.html#section-6.1.2
+        // "Minimum time of kGranularity before packets are deemed lost."
+        lossDelay = Integer.max(lossDelay, kGranularity);
         Instant lostSendTime = Instant.now(clock).minusMillis(lossDelay);
 
         // https://www.rfc-editor.org/rfc/rfc9002.html#section-6.1

--- a/core/src/test/java/tech/kwik/core/recovery/LossDetectorTest.java
+++ b/core/src/test/java/tech/kwik/core/recovery/LossDetectorTest.java
@@ -212,6 +212,24 @@ class LossDetectorTest extends RecoveryTests {
     }
 
     @Test
+    void zeroRttDoesNotCauseAssertionErrorInLossDelayCalculation() {
+        // Given both smoothed and latest rtt are reported as 0, which can happen on very fast (e.g. loopback)
+        // connections, because rtt is measured with millisecond resolution.
+        when(rttEstimator.getSmoothedRtt()).thenReturn(0);
+        when(rttEstimator.getLatestRtt()).thenReturn(0);
+
+        lossDetector.packetSent(createPacket(6), clock.instant(), lostPacket -> lostPacketHandler.process(lostPacket));
+        lossDetector.packetSent(createPacket(8), clock.instant(), lostPacket -> lostPacketHandler.process(lostPacket));
+
+        // When (only) the second packet is acked, right after it was sent (no time has passed)
+        lossDetector.onAckReceived(new AckFrame(new Range(8L)), clock.instant());
+
+        // Then no exception is thrown, and the first packet is not (yet) declared lost, because it was sent
+        // less than the minimum loss delay (kGranularity) ago.
+        verify(lostPacketHandler, never()).process(any(QuicPacket.class));
+    }
+
+    @Test
     void oldPacketLaterThanLargestAcknowledgedIsNotDeclaredLost() {
         Instant now = Instant.now();
         int timeDiff = (defaultRtt * 9 / 8) + 10;


### PR DESCRIPTION

- RttEstimator.addSample() computes rttSample = Du — i.e. RTT is measured with millisecond granularity. On a loopback connection on a very fast
 machine, a packet can be sent and ACKed within the same millisecond, producing an RTT sample of 0.
 Because smoothedRtt is initialized from the very first sample (RttEstimator.java:85-89), both                        getSmoothedRtt() and getLatestRtt() can legitimately return 0.
 - LossDetector.detectLostPackets() (line 176) then computes
 lossDelay = (int) (kTimeThreshold * max(smoothedRtt, latestRtt)), which becomes 0.
 - Line 177 has assert(lossDelay > 0);  // Minimum time of kGranularity before packets are deemed lost
 — the comment correctly states the intent (RFC 9002 §6.1.2's kGranularity floor), but the code
 never actually enforces that floor; it only asserts it holds, and then crashes when it doesn't.
 grep confirms kGranularity is not defined/used as a real constant anywhere in core/src/main.
 This assert has been present unchanged since 2021 (git log -L170,180:...LossDetector.java), so
 it's a latent bug that simply never triggered before on typical (slower, non-loopback, or
 higher-latency) RTTs.

 Per RFC 9002 §6.1.2 ("Time Threshold"):
 loss_delay = kTimeThreshold * max(latest_rtt, smoothed_rtt)
 loss_delay = max(loss_delay, kGranularity)
 kGranularity is defined (Appendix A.1) with a recommended value of 1 ms. Kwik implements the
 first line but omits the second (the actual clamp) — that's the bug. It's not just a test-only
 assertion glitch: without -ea, the same code path would compute lostSendTime = now (no floor),
 which would make sentTimeTooLongAgo() trigger for essentially any unacked in-flight packet,
 causing premature/spurious loss declarations on very fast/low-latency paths — a real correctness
 issue, not merely an assertion nuisance.

 Fix:

 In core/src/main/java/tech/kwik/core/recovery/LossDetector.java:
 1. Add a kGranularity constant (1 ms, per RFC 9002 Appendix A.1), alongside the existing
 kTimeThreshold / kPacketThreshold constants (~line 47-48).
 2. Replace the assert(lossDelay > 0) at line 177 with an actual clamp:
 int lossDelay = (int) (kTimeThreshold * Integer.max(rttEstimater.getSmoothedRtt(), rttEstimater.getLatestRtt()));
 // https://www.rfc-editor.org/rfc/rfc9002.html#section-6.1.2
 // "Minimum time of kGranularity before packets are deemed lost."
 lossDelay = Integer.max(lossDelay, kGranularity);
 Instant lostSendTime = Instant.now(clock).minusMillis(lossDelay);
 2. This keeps the existing RFC-reference comment style used throughout the file and removes the
 crash-prone assertion entirely (no need to keep it, since the Integer.max now makes it
 unconditionally true).